### PR TITLE
Fixed version check failing

### DIFF
--- a/xap.cpp
+++ b/xap.cpp
@@ -408,6 +408,7 @@ std::string slurpFile(const std::string& absolutePath) {
 
     file.close();
     std::erase(contents, '\n');
+    std::erase(contents, '\r');
     return contents;
 }
 


### PR DESCRIPTION
For some reason, the `gameversion.txt` file now has a carriage return character, not just a newline character.
Erasing this from any content passing through `slurpFile()` will not pose any other issues, as it's only used for slurping the `libraryfolders.vdf` file, which can be parsed either way, and `gameversion.txt` file.