### PR TITLE
Fix XGrabKey error once and for all

### DIFF
--- a/Utils/InputTypes.hpp
+++ b/Utils/InputTypes.hpp
@@ -151,6 +151,7 @@ InputKeyType mapKeyboardKeyType(int keyCode) {
         case KEY_LEFTSHIFT: return InputKeyType::KEYBOARD_LEFT_SHIFT;
         case KEY_LEFTCTRL: return InputKeyType::KEYBOARD_LEFT_CTRL;
         case KEY_LEFTALT: return InputKeyType::KEYBOARD_LEFT_ALT;
+        case KEY_INSERT: return InputKeyType::KEYBOARD_INSERT;
         case KEY_SPACE: return InputKeyType::KEYBOARD_SPACE;
         default: return InputKeyType::INPUT_UNKNOWN;
         none: return InputKeyType::INPUT_NONE;


### PR DESCRIPTION
Why were we even using that in the first place?
We can utilize the perfectly fine input manager we already have in the project... There is no need to be greedy and use XGrabKey, which tries to prevent other applications from accessing that key. At least in my opinion...

This commit removes that and should not interfere with anything else, but I think for a rework you should probably look into not having a separate thread just for checking whether the menu key was pressed. Don't fret, I'm none the wiser right now!