### PR TITLE
Fix spec. list & watermark spec. count differing

### DIFF
--- a/Features/Sense.hpp
+++ b/Features/Sense.hpp
@@ -694,8 +694,8 @@ struct Sense
 
 		if (!Map->IsPlayable)
 			return;
-		//if (!Features::Settings::DeadCheck && Myself->IsDead)
-		//	return;
+		if (!Features::Settings::DeadCheck && Myself->IsDead)
+			return;
 		if (!Features::Settings::OverlayEnabled)
 			return;
 


### PR DESCRIPTION
I wasn't able to fully test in-game due to lack of time, but it should work just fine.
Moved the spectator update process to a separate function that either gets called from the watermark, or if the watermark is disabled, then from the spectator list.
Previously, you had the new spectator check implemented for only one of those two, the other one was still using the old method.